### PR TITLE
Add base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM solanalabs/rust:1.68.0
+
+RUN apt-get update && apt-get install -qy clang libudev-dev tmux vim git netcat zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+WORKDIR /build
+
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.14.14/install)"
+ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
+CMD /bin/zsh


### PR DESCRIPTION
This almost certainly not be the end-state as I would rather rely on the native rust Dockerfile than the solanalabs Dockerfile. However, what we can potentially do is pass in parameters for the first line which pulls from a known whitelist:
```
FROM $BASE_RUST_IMAGE
```
Then for the solana install, the version should also be scoped.