### PR TITLE
fix: cli help msg for --library-name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -716,7 +716,7 @@ pub async fn verify_from_repo(
                                 options
                             );
                             println!(
-                                "Please explicitly specify the target with the --package-name <name> option",
+                                "Please explicitly specify the target with the --library-name <name> option",
                             );
                             Err(anyhow::format_err!(
                                 "Failed to find unique Cargo.toml file in root directory"


### PR DESCRIPTION
Hey! I noticed while trying this bad boy out that the help message that appears when you try to clone a repository with a cargo workspace appears like this:

```text
Please explicitly specify the target with the --package-name <name> option
```

It should instead tell you to use `--library-name`.