### PR TITLE
Fix builds with Solana v1.17+ by using sparse index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "cargo-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
#### Problem

Builds using Solana v1.17 and above will typically use Rust v1.73, which means that the sparse registry index is used by default.

So when the tool runs `cargo fetch`, the command fetches the sparse index info.

However, the Solana build tools are still on Rust 1.68, which doesn't default to the sparse registry, so when running `cargo build-sbf -- --frozen --locked`, cargo will try to access the network to get the git registry, which naturally causes a failure because of the `--frozen` flag.

#### Solution

It's a slightly clunky solution, but since `cargo config` is only available on nightly, I went the lazy route and use the old build steps for anything less than 1.17, and force always using the sparse registry for anything greater than that while relaxing the `--frozen` restriction.

Let me know what you think!