### PR TITLE
Added Optional Resources Limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "cargo-lock",

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ cargo install solana-verify
 ```
 
 If you want to pin the version:
+
 ```
 # Pulls the latest version from crates.io
 cargo install solana-verify --version $VERSION
 ```
 
 If you are extra cautious and want to install a version of the binary that maps 1-to-1 with a specific commit, run the following. This example is installing version 0.2.6 from revision `13a1db2`:
+
 ```
 # Pulls the source from git. Change the argument to --rev to the desired commit
 cargo install solana-verify --git https://github.com/Ellipsis-Labs/solana-verifiable-build --rev 13a1db2
@@ -139,11 +141,13 @@ Program hash matches ✅
 ```
 
 ### Marginfi V2
+
 ```
 solana-verify verify-from-repo -um --program-id MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA https://github.com/mrgnlabs/marginfi-v2 --library-name marginfi -- --features mainnet-beta
 ```
 
 Final Output:
+
 ```
 Executable Program Hash from repo: 7b37482dd6b2159932b5c2595bc6ce62cf6e587ae67f237c8152b802bf7d7bb8
 On-chain Program Hash: 7b37482dd6b2159932b5c2595bc6ce62cf6e587ae67f237c8152b802bf7d7bb8
@@ -151,11 +155,13 @@ Program hash matches ✅
 ```
 
 ### Solend
+
 ```
 solana-verify verify-from-repo -um --program-id So1endDq2YkqhipRh3WViPa8hdiSpxWy6z3Z6tMCpAo https://github.com/solendprotocol/solana-program-library --library-name solend_program -b ellipsislabs/solana:1.14.10 --bpf
 ```
 
 Final Output:
+
 ```
 Executable Program Hash from repo: f89a43677ab106d2e50d3c41b656d067b6142c02a2508caca1c11c0a963d3b17
 On-chain Program Hash: f89a43677ab106d2e50d3c41b656d067b6142c02a2508caca1c11c0a963d3b17
@@ -229,12 +235,12 @@ This will return the hash of the stripped executable, which should match the has
 
 ```
 
-### To send verification to Osec API
+### To send verification to OtterSec API
 
 ```bash
 solana-verify verify-from-repo --remote -um --program-id PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY https://github.com/Ellipsis-Labs/phoenix-v1
 ```
 
-- This verification will be sent to the Osec API and will be available at [https://verify.osec.io/status](https://verify.osec.io/status/PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY)
+- This verification will be sent to the OtterSec API and will be available at [https://verify.osec.io/status](https://verify.osec.io/status/PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY)
 
-> Note: The `--remote` flag is required to send the verification to the Osec API. The `--remote` flag is not required for local verification. And this will take 5-10 minutes to complete.
+> Note: The `--remote` flag is required to send the verification to the OtterSec API. The `--remote` flag is not required for local verification. And this will take 5-10 minutes to complete.

--- a/build-all-images.sh
+++ b/build-all-images.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Change directory to where the Dockerfiles are located
+cd ./docker
+
+# Iterate over each Dockerfile in the directory
+for dockerfile in *; do
+    # Check if the file is actually a Dockerfile
+    if [ -f "$dockerfile" ] && [ "${dockerfile##*.}" == "Dockerfile" ]; then
+        # Extract image name from Dockerfile name
+        image_name="${dockerfile%Dockerfile}"
+        # Remove the last character from the image name
+        image_name="${image_name%?}"
+        # Interpolate image_name with "solana."
+        image_name="solana.$image_name"
+        echo "Building image: $image_name"
+        # Build the Docker image
+        docker build -t "$image_name" -f "$dockerfile" .
+    fi
+done

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,7 +429,7 @@ pub fn build(
     // change directory to program/build dir
     let mount_params = format!("{}:{}", mount_path, workdir);
     let container_id = std::process::Command::new("docker")
-        .args(["run", "--rm", "-v", &mount_params, "-dit", &image, "bash"])
+        .args(["run", "--rm", "-v", &mount_params, "-dit","--memory=4g","--cpus=2", &image, "bash"])
         .stderr(Stdio::inherit())
         .output()
         .map_err(|e| anyhow::format_err!("Docker build failed: {}", e.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,21 @@ pub fn get_genesis_hash(url: Option<String>) -> anyhow::Result<String> {
     Ok(genesis_hash.to_string())
 }
 
+
+pub fn get_docker_resource_limits() -> Option<(String, String)> {
+    let memory = std::env::var("SVB_DOCKER_MEMORY_LIMIT").ok();
+    let cpus = std::env::var("SVB_DOCKER_CPU_LIMIT").ok();
+    if memory.is_some() || cpus.is_some() {
+        println!("Using docker resource limits: memory: {:?}, cpus: {:?}", memory, cpus);
+    } else {
+        // Print message to user that they can set these environment variables to limit docker resources
+        println!("No Docker resource limits are set.");
+        println!("You can set the SVB_DOCKER_MEMORY_LIMIT and SVB_DOCKER_CPU_LIMIT environment variables to limit Docker resources.");
+        println!("For example: SVB_DOCKER_MEMORY_LIMIT=2g SVB_DOCKER_CPU_LIMIT=2.");
+    }
+    memory.zip(cpus)
+}
+
 pub fn build(
     mount_directory: Option<String>,
     library_name: Option<String>,
@@ -428,12 +443,22 @@ pub fn build(
 
     // change directory to program/build dir
     let mount_params = format!("{}:{}", mount_path, workdir);
-    let container_id = std::process::Command::new("docker")
-        .args(["run", "--rm", "-v", &mount_params, "-dit","--memory=4g","--cpus=2", &image, "bash"])
-        .stderr(Stdio::inherit())
-        .output()
-        .map_err(|e| anyhow::format_err!("Docker build failed: {}", e.to_string()))
-        .and_then(|output| parse_output(output.stdout))?;
+    let container_id = {
+        let mut cmd = std::process::Command::new("docker");
+            cmd.args(["run", "--rm", "-v", &mount_params, "-dit"]);
+            cmd.stderr(Stdio::inherit());
+
+        if let Some((memory_limit, cpu_limit)) = get_docker_resource_limits() {
+            cmd.arg("--memory").arg(memory_limit).arg("--cpus").arg(cpu_limit);
+        }
+
+        let output = cmd
+            .args([&image, "bash"])
+            .output()
+            .map_err(|e| anyhow!("Docker build failed: {}", e.to_string()))?;
+
+        parse_output(output.stdout)?
+    };
 
     // Set the container id so we can kill it later if the process is interrupted
     container_id_opt.replace(container_id.clone());
@@ -532,11 +557,22 @@ pub fn verify_from_image(
 
     println!("Workdir: {}", workdir);
 
-    let container_id = std::process::Command::new("docker")
-        .args(["run", "--rm", "-dit", image.as_str()])
-        .output()
-        .map_err(|e| anyhow::format_err!("Failed to run image {}", e.to_string()))
-        .and_then(|output| parse_output(output.stdout))?;
+
+    let container_id = {
+        let mut cmd = std::process::Command::new("docker");
+            cmd.args(["run", "--rm", "-dit"]);
+            cmd.stderr(Stdio::inherit());
+
+        if let Some((memory_limit, cpu_limit)) = get_docker_resource_limits() {
+            cmd.arg("--memory").arg(memory_limit).arg("--cpus").arg(cpu_limit);
+        }
+
+        let output = cmd
+            .args([&image])
+            .output()
+            .map_err(|e| anyhow!("Docker build failed: {}", e.to_string()))?;
+        parse_output(output.stdout)?
+    };
 
     container_id_opt.replace(container_id.clone());
 


### PR DESCRIPTION
- We can now specify limits for docker resource utilisation. For example we can use `SVB_DOCKER_MEMORY_LIMIT=2g` `SVB_DOCKER_CPU_LIMIT=2` to specify limits.
- Added a script `build-all-images.sh` to build all the images in `/docker` folder.