### PR TITLE
Find correct version of rust for docker file generation

### DIFF
--- a/docker/v1.16.0.Dockerfile
+++ b/docker/v1.16.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.0/install)"

--- a/docker/v1.16.0.Dockerfile
+++ b/docker/v1.16.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.0/install)"

--- a/docker/v1.16.1.Dockerfile
+++ b/docker/v1.16.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.1/install)"

--- a/docker/v1.16.1.Dockerfile
+++ b/docker/v1.16.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.1/install)"

--- a/docker/v1.16.10.Dockerfile
+++ b/docker/v1.16.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.10/install)"

--- a/docker/v1.16.10.Dockerfile
+++ b/docker/v1.16.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.10/install)"

--- a/docker/v1.16.11.Dockerfile
+++ b/docker/v1.16.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.11/install)"

--- a/docker/v1.16.11.Dockerfile
+++ b/docker/v1.16.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.11/install)"

--- a/docker/v1.16.12.Dockerfile
+++ b/docker/v1.16.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.12/install)"

--- a/docker/v1.16.12.Dockerfile
+++ b/docker/v1.16.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.12/install)"

--- a/docker/v1.16.13.Dockerfile
+++ b/docker/v1.16.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.13/install)"

--- a/docker/v1.16.13.Dockerfile
+++ b/docker/v1.16.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.13/install)"

--- a/docker/v1.16.14.Dockerfile
+++ b/docker/v1.16.14.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.14/install)"

--- a/docker/v1.16.14.Dockerfile
+++ b/docker/v1.16.14.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.14/install)"

--- a/docker/v1.16.15.Dockerfile
+++ b/docker/v1.16.15.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.15/install)"

--- a/docker/v1.16.15.Dockerfile
+++ b/docker/v1.16.15.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.15/install)"

--- a/docker/v1.16.16.Dockerfile
+++ b/docker/v1.16.16.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.16/install)"

--- a/docker/v1.16.16.Dockerfile
+++ b/docker/v1.16.16.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.16/install)"

--- a/docker/v1.16.17.Dockerfile
+++ b/docker/v1.16.17.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.17/install)"

--- a/docker/v1.16.17.Dockerfile
+++ b/docker/v1.16.17.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.17/install)"

--- a/docker/v1.16.18.Dockerfile
+++ b/docker/v1.16.18.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.18/install)"

--- a/docker/v1.16.18.Dockerfile
+++ b/docker/v1.16.18.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.18/install)"

--- a/docker/v1.16.19.Dockerfile
+++ b/docker/v1.16.19.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.19/install)"

--- a/docker/v1.16.19.Dockerfile
+++ b/docker/v1.16.19.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.19/install)"

--- a/docker/v1.16.2.Dockerfile
+++ b/docker/v1.16.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.2/install)"

--- a/docker/v1.16.2.Dockerfile
+++ b/docker/v1.16.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.2/install)"

--- a/docker/v1.16.20.Dockerfile
+++ b/docker/v1.16.20.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.20/install)"

--- a/docker/v1.16.20.Dockerfile
+++ b/docker/v1.16.20.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.20/install)"

--- a/docker/v1.16.21.Dockerfile
+++ b/docker/v1.16.21.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.21/install)"

--- a/docker/v1.16.21.Dockerfile
+++ b/docker/v1.16.21.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.21/install)"

--- a/docker/v1.16.22.Dockerfile
+++ b/docker/v1.16.22.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.22/install)"

--- a/docker/v1.16.22.Dockerfile
+++ b/docker/v1.16.22.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.22/install)"

--- a/docker/v1.16.23.Dockerfile
+++ b/docker/v1.16.23.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.23/install)"

--- a/docker/v1.16.23.Dockerfile
+++ b/docker/v1.16.23.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.23/install)"

--- a/docker/v1.16.24.Dockerfile
+++ b/docker/v1.16.24.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.24/install)"

--- a/docker/v1.16.24.Dockerfile
+++ b/docker/v1.16.24.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.24/install)"

--- a/docker/v1.16.25.Dockerfile
+++ b/docker/v1.16.25.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.25/install)"

--- a/docker/v1.16.25.Dockerfile
+++ b/docker/v1.16.25.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.25/install)"

--- a/docker/v1.16.26.Dockerfile
+++ b/docker/v1.16.26.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.26/install)"

--- a/docker/v1.16.26.Dockerfile
+++ b/docker/v1.16.26.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.26/install)"

--- a/docker/v1.16.27.Dockerfile
+++ b/docker/v1.16.27.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.27/install)"

--- a/docker/v1.16.27.Dockerfile
+++ b/docker/v1.16.27.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.27/install)"

--- a/docker/v1.16.3.Dockerfile
+++ b/docker/v1.16.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.3/install)"

--- a/docker/v1.16.3.Dockerfile
+++ b/docker/v1.16.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.3/install)"

--- a/docker/v1.16.4.Dockerfile
+++ b/docker/v1.16.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.4/install)"

--- a/docker/v1.16.4.Dockerfile
+++ b/docker/v1.16.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.4/install)"

--- a/docker/v1.16.5.Dockerfile
+++ b/docker/v1.16.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.5/install)"

--- a/docker/v1.16.5.Dockerfile
+++ b/docker/v1.16.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.5/install)"

--- a/docker/v1.16.6.Dockerfile
+++ b/docker/v1.16.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.6/install)"

--- a/docker/v1.16.6.Dockerfile
+++ b/docker/v1.16.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.6/install)"

--- a/docker/v1.16.7.Dockerfile
+++ b/docker/v1.16.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.7/install)"

--- a/docker/v1.16.7.Dockerfile
+++ b/docker/v1.16.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.7/install)"

--- a/docker/v1.16.8.Dockerfile
+++ b/docker/v1.16.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.8/install)"

--- a/docker/v1.16.8.Dockerfile
+++ b/docker/v1.16.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.8/install)"

--- a/docker/v1.16.9.Dockerfile
+++ b/docker/v1.16.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.9/install)"

--- a/docker/v1.16.9.Dockerfile
+++ b/docker/v1.16.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.9/install)"

--- a/docker/v1.17.0.Dockerfile
+++ b/docker/v1.17.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:6562d50b62366d5b9db92b34c6684fab5bf3b9f627e59a863c9c0675760feed4
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.0/install)"

--- a/docker/v1.17.0.Dockerfile
+++ b/docker/v1.17.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:6562d50b62366d5b9db92b34c6684fab5bf3b9f627e59a863c9c0675760feed4
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.0/install)"

--- a/docker/v1.17.1.Dockerfile
+++ b/docker/v1.17.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.1/install)"

--- a/docker/v1.17.1.Dockerfile
+++ b/docker/v1.17.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.1/install)"

--- a/docker/v1.17.10.Dockerfile
+++ b/docker/v1.17.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.10/install)"

--- a/docker/v1.17.10.Dockerfile
+++ b/docker/v1.17.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.10/install)"

--- a/docker/v1.17.11.Dockerfile
+++ b/docker/v1.17.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.11/install)"

--- a/docker/v1.17.11.Dockerfile
+++ b/docker/v1.17.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.11/install)"

--- a/docker/v1.17.12.Dockerfile
+++ b/docker/v1.17.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.12/install)"

--- a/docker/v1.17.12.Dockerfile
+++ b/docker/v1.17.12.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.12/install)"

--- a/docker/v1.17.13.Dockerfile
+++ b/docker/v1.17.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.13/install)"

--- a/docker/v1.17.13.Dockerfile
+++ b/docker/v1.17.13.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.13/install)"

--- a/docker/v1.17.14.Dockerfile
+++ b/docker/v1.17.14.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.14/install)"

--- a/docker/v1.17.14.Dockerfile
+++ b/docker/v1.17.14.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.14/install)"

--- a/docker/v1.17.15.Dockerfile
+++ b/docker/v1.17.15.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.15/install)"

--- a/docker/v1.17.15.Dockerfile
+++ b/docker/v1.17.15.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.15/install)"

--- a/docker/v1.17.16.Dockerfile
+++ b/docker/v1.17.16.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.16/install)"

--- a/docker/v1.17.16.Dockerfile
+++ b/docker/v1.17.16.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.16/install)"

--- a/docker/v1.17.17.Dockerfile
+++ b/docker/v1.17.17.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.17/install)"

--- a/docker/v1.17.17.Dockerfile
+++ b/docker/v1.17.17.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.17/install)"

--- a/docker/v1.17.18.Dockerfile
+++ b/docker/v1.17.18.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.18/install)"

--- a/docker/v1.17.18.Dockerfile
+++ b/docker/v1.17.18.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.18/install)"

--- a/docker/v1.17.19.Dockerfile
+++ b/docker/v1.17.19.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.19/install)"

--- a/docker/v1.17.19.Dockerfile
+++ b/docker/v1.17.19.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.19/install)"

--- a/docker/v1.17.2.Dockerfile
+++ b/docker/v1.17.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.2/install)"

--- a/docker/v1.17.2.Dockerfile
+++ b/docker/v1.17.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.2/install)"

--- a/docker/v1.17.20.Dockerfile
+++ b/docker/v1.17.20.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.20/install)"

--- a/docker/v1.17.20.Dockerfile
+++ b/docker/v1.17.20.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.20/install)"

--- a/docker/v1.17.21.Dockerfile
+++ b/docker/v1.17.21.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.21/install)"

--- a/docker/v1.17.21.Dockerfile
+++ b/docker/v1.17.21.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.21/install)"

--- a/docker/v1.17.22.Dockerfile
+++ b/docker/v1.17.22.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.22/install)"

--- a/docker/v1.17.22.Dockerfile
+++ b/docker/v1.17.22.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.22/install)"

--- a/docker/v1.17.23.Dockerfile
+++ b/docker/v1.17.23.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.23/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.23.Dockerfile
+++ b/docker/v1.17.23.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.23/install)"

--- a/docker/v1.17.23.Dockerfile
+++ b/docker/v1.17.23.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.23/install)"

--- a/docker/v1.17.24.Dockerfile
+++ b/docker/v1.17.24.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.24/install)"

--- a/docker/v1.17.24.Dockerfile
+++ b/docker/v1.17.24.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.24/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.24.Dockerfile
+++ b/docker/v1.17.24.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.24/install)"

--- a/docker/v1.17.25.Dockerfile
+++ b/docker/v1.17.25.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.25/install)"

--- a/docker/v1.17.25.Dockerfile
+++ b/docker/v1.17.25.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.25/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.25.Dockerfile
+++ b/docker/v1.17.25.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.25/install)"

--- a/docker/v1.17.26.Dockerfile
+++ b/docker/v1.17.26.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.26/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.26.Dockerfile
+++ b/docker/v1.17.26.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.26/install)"

--- a/docker/v1.17.26.Dockerfile
+++ b/docker/v1.17.26.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.26/install)"

--- a/docker/v1.17.27.Dockerfile
+++ b/docker/v1.17.27.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.27/install)"

--- a/docker/v1.17.27.Dockerfile
+++ b/docker/v1.17.27.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.27/install)"

--- a/docker/v1.17.27.Dockerfile
+++ b/docker/v1.17.27.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.27/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.28.Dockerfile
+++ b/docker/v1.17.28.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.28/install)"

--- a/docker/v1.17.28.Dockerfile
+++ b/docker/v1.17.28.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.28/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.28.Dockerfile
+++ b/docker/v1.17.28.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.28/install)"

--- a/docker/v1.17.29.Dockerfile
+++ b/docker/v1.17.29.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.29/install)"

--- a/docker/v1.17.29.Dockerfile
+++ b/docker/v1.17.29.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.29/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.29.Dockerfile
+++ b/docker/v1.17.29.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.29/install)"

--- a/docker/v1.17.3.Dockerfile
+++ b/docker/v1.17.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.3/install)"

--- a/docker/v1.17.3.Dockerfile
+++ b/docker/v1.17.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.3/install)"

--- a/docker/v1.17.30.Dockerfile
+++ b/docker/v1.17.30.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.30/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.30.Dockerfile
+++ b/docker/v1.17.30.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.30/install)"

--- a/docker/v1.17.30.Dockerfile
+++ b/docker/v1.17.30.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.30/install)"

--- a/docker/v1.17.31.Dockerfile
+++ b/docker/v1.17.31.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"

--- a/docker/v1.17.31.Dockerfile
+++ b/docker/v1.17.31.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"

--- a/docker/v1.17.31.Dockerfile
+++ b/docker/v1.17.31.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.31/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.17.4.Dockerfile
+++ b/docker/v1.17.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.4/install)"

--- a/docker/v1.17.4.Dockerfile
+++ b/docker/v1.17.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.4/install)"

--- a/docker/v1.17.5.Dockerfile
+++ b/docker/v1.17.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.5/install)"

--- a/docker/v1.17.5.Dockerfile
+++ b/docker/v1.17.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.5/install)"

--- a/docker/v1.17.6.Dockerfile
+++ b/docker/v1.17.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"

--- a/docker/v1.17.6.Dockerfile
+++ b/docker/v1.17.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.6/install)"

--- a/docker/v1.17.7.Dockerfile
+++ b/docker/v1.17.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.7/install)"

--- a/docker/v1.17.7.Dockerfile
+++ b/docker/v1.17.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.7/install)"

--- a/docker/v1.17.8.Dockerfile
+++ b/docker/v1.17.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.8/install)"

--- a/docker/v1.17.8.Dockerfile
+++ b/docker/v1.17.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.8/install)"

--- a/docker/v1.17.9.Dockerfile
+++ b/docker/v1.17.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.9/install)"

--- a/docker/v1.17.9.Dockerfile
+++ b/docker/v1.17.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:7ec316528af3582341280f667be6cfd93062a10d104f3b1ea72cd1150c46ef22
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.9/install)"

--- a/docker/v1.18.0.Dockerfile
+++ b/docker/v1.18.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"

--- a/docker/v1.18.0.Dockerfile
+++ b/docker/v1.18.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"

--- a/docker/v1.18.1.Dockerfile
+++ b/docker/v1.18.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.1/install)"

--- a/docker/v1.18.1.Dockerfile
+++ b/docker/v1.18.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.1/install)"

--- a/docker/v1.18.10.Dockerfile
+++ b/docker/v1.18.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.10/install)"

--- a/docker/v1.18.10.Dockerfile
+++ b/docker/v1.18.10.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.10/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.10.Dockerfile
+++ b/docker/v1.18.10.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.10/install)"

--- a/docker/v1.18.11.Dockerfile
+++ b/docker/v1.18.11.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.11/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.11.Dockerfile
+++ b/docker/v1.18.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.11/install)"

--- a/docker/v1.18.11.Dockerfile
+++ b/docker/v1.18.11.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.11/install)"

--- a/docker/v1.18.2.Dockerfile
+++ b/docker/v1.18.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.2/install)"

--- a/docker/v1.18.2.Dockerfile
+++ b/docker/v1.18.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.2/install)"

--- a/docker/v1.18.3.Dockerfile
+++ b/docker/v1.18.3.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.3/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.3.Dockerfile
+++ b/docker/v1.18.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.3/install)"

--- a/docker/v1.18.3.Dockerfile
+++ b/docker/v1.18.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.3/install)"

--- a/docker/v1.18.4.Dockerfile
+++ b/docker/v1.18.4.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.4/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.4.Dockerfile
+++ b/docker/v1.18.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.4/install)"

--- a/docker/v1.18.4.Dockerfile
+++ b/docker/v1.18.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.4/install)"

--- a/docker/v1.18.5.Dockerfile
+++ b/docker/v1.18.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.5/install)"

--- a/docker/v1.18.5.Dockerfile
+++ b/docker/v1.18.5.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.5/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.5.Dockerfile
+++ b/docker/v1.18.5.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.5/install)"

--- a/docker/v1.18.6.Dockerfile
+++ b/docker/v1.18.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.6/install)"

--- a/docker/v1.18.6.Dockerfile
+++ b/docker/v1.18.6.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.6/install)"

--- a/docker/v1.18.6.Dockerfile
+++ b/docker/v1.18.6.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.6/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.7.Dockerfile
+++ b/docker/v1.18.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.7/install)"

--- a/docker/v1.18.7.Dockerfile
+++ b/docker/v1.18.7.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.7/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.7.Dockerfile
+++ b/docker/v1.18.7.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.7/install)"

--- a/docker/v1.18.8.Dockerfile
+++ b/docker/v1.18.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.8/install)"

--- a/docker/v1.18.8.Dockerfile
+++ b/docker/v1.18.8.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.8/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/docker/v1.18.8.Dockerfile
+++ b/docker/v1.18.8.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.8/install)"

--- a/docker/v1.18.9.Dockerfile
+++ b/docker/v1.18.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
+FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.9/install)"

--- a/docker/v1.18.9.Dockerfile
+++ b/docker/v1.18.9.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rust@sha256:79892de83d1af9109c47a4566a24a0b240348bb8c088f1bccc52645c4c70ec39
+FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.9/install)"

--- a/docker/v1.18.9.Dockerfile
+++ b/docker/v1.18.9.Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 rust@sha256:b7f381685785bb4192e53995d6ad1dec70954e682e18e06a4c8c02011ab2f32e
 
 RUN apt-get update && apt-get install -qy git gnutls-bin
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.18.9/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 WORKDIR /build
 

--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -86,7 +86,7 @@ for release in tags:
 
     if rust_version not in RUST_DOCKER_IMAGESHA_MAP:
         response = requests.get(
-            "https://hub.docker.com/v2/namespaces/library/repositories/rust/tags/1.68.0-bullseye"
+            f"https://hub.docker.com/v2/namespaces/library/repositories/rust/tags/{rust_version}-bullseye"
         )
 
         if response.status_code == 200:


### PR DESCRIPTION
### PR

- Look at rust version in `rust-toolchain.toml` of each solana tagged release and associate it with a the correct rust version.

- Generate dockerfiles using new python generation script