### PR TITLE
Prefix with single Dockerfile publish with `autopr`

### DIFF
--- a/.github/workflows/generate_dockerfiles.yml
+++ b/.github/workflows/generate_dockerfiles.yml
@@ -48,7 +48,7 @@ jobs:
             This PR updates the Dockerfiles in the `docker/` directory.
             
             Generated automatically by the Generate Dockerfiles workflow.
-          branch: update-dockerfiles
+          branch: autopr-update-dockerfiles
           delete-branch: true
           base: master
           labels: |


### PR DESCRIPTION
Make it easier to distinguish branches created by CI