### PR TITLE
Add CI workflow to publish a single Docker image

### DIFF
--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -53,7 +53,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ghcr.io/{{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
+            ghcr.io/${{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
@@ -61,6 +61,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/{{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
+          subject-name: ghcr.io/${{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -7,7 +7,7 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Publish Docker image
+name: Publish Docker Image
 
 on:
   workflow_dispatch:
@@ -61,6 +61,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
+          subject-name: ghcr.io/${{ github.repository_owner }}/solana
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -1,0 +1,66 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Solana version to generate Dockerfile for (e.g., 1.16.0)'
+        required: true
+        type: string
+
+jobs:
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: docker/
+          file: docker/v${{ github.event.inputs.version }}.Dockerfile
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ghcr.io/solana.${{ github.event.inputs.version }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghci.io/solana.${{ github.event.inputs.version }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -53,7 +53,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ghcr.io/solana.${{ github.event.inputs.version }}
+            ghcr.io/{{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
@@ -61,6 +61,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghci.io/solana.${{ github.event.inputs.version }}
+          subject-name: ghcr.io/{{ github.repository_owner }}/solana:${{ github.event.inputs.version }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -1,13 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
-name: Publish Docker Image
+name: Publish Single Docker Image
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
CI job takes a version number to build an image from. A docker file with that version has to exist under `docker/`