### PR TITLE
Add `list-program-pdas`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4037,6 +4037,7 @@ dependencies = [
  "serde_json",
  "sha256",
  "signal-hook",
+ "solana-account-decoder",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ solana-cli-config = "=1.18.23"
 solana-client = "=1.18.23"
 solana-sdk = "=1.18.23"
 tokio = { version = "1.29.1", features = ["full"] }
+solana-account-decoder = "1.18.23"
 
 [dependencies.uuid]
 version = "1.2.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,9 @@ async fn main() -> anyhow::Result<()> {
         .subcommand(SubCommand::with_name("list-program-pdas")
             .about("List all the PDA information associated with a program ID")
             .arg(Arg::with_name("program-id")
+                .long("program-id")
                 .required(true)
+                .takes_value(true)
                 .help("Program ID of the program to list PDAs for")))
         .get_matches();
 
@@ -1128,6 +1130,5 @@ pub async fn list_program_pdas(program_id: Pubkey, url: Option<String>) -> anyho
         println!("----------------------------------------------------------------");
         println!("{}", build_params);
     }
-    // println!("PDAs for program {}: {:?}", program_id, pdas);
     Ok(())
 }

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -310,7 +310,10 @@ pub async fn process_close(program_address: Pubkey) -> anyhow::Result<()> {
         )?;
     } else {
         return Err(anyhow!(
-            "Program account does not exist. Please provide the program address not PDA address."
+            "No PDA found for signer {:?} and program address {:?}. Make sure you are providing the program address, not the PDA address. Check that a signer exists for the program by running `solana-verify list-program-pdas --program-id {:?}`",
+            signer_pubkey,
+            program_address,
+            program_address
         ));
     }
 


### PR DESCRIPTION
Includes fixes for `verify-from-repo`
- `-y` now skips all prompts
- adds `-k` to specify keypair when using `verify-from-repo`

Improves `close` command, now tells users to check `list-program-pdas`