### PR TITLE
Release 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
# Release 0.3.1

New features
- `list-program-pdas` lists all build information submitted for a program, requires custom RPC Url, useful for debugging remote verification, which expects the program authority or OTTER SIGNER
- `get-program-pda` gets the build information submitted by a specific signer (ie whatever is in `~/.config/solana`) or explicitly specified by `-s <address>`
- `verify-from-repo` has `-k` flag to specify keypair to write build information onchain after successful verification

Fixes
- `verify-from-repo` 's skip prompt flag `-y` now skips ALL prompts
