### PR TITLE
Verify with signer

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -13,6 +13,7 @@ use crate::api::models::{
     VerifyResponse,
 };
 use crate::solana_program::get_program_pda;
+use crate::{get_genesis_hash, MAINNET_GENESIS_HASH};
 
 // URL for the remote server
 pub const REMOTE_SERVER_URL: &str = "https://verify.osec.io";
@@ -120,6 +121,10 @@ pub async fn send_job_with_uploader_to_remote(
     uploader: &Pubkey,
 ) -> anyhow::Result<()> {
     // Check that PDA exists before sending job
+    let genesis_hash = get_genesis_hash(connection)?;
+    if genesis_hash != MAINNET_GENESIS_HASH {
+        return Err(anyhow!("Remote verification only works with mainnet. Please omit the --remote flag to verify locally."));
+    }
     get_program_pda(connection, program_id, Some(uploader.to_string())).await?;
 
     let client = Client::builder()

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,8 +1,9 @@
 use anyhow::anyhow;
 use crossbeam_channel::{unbounded, Receiver};
 use indicatif::{HumanDuration, ProgressBar, ProgressStyle};
-use reqwest::Client;
+use reqwest::{Client, Response};
 use serde_json::json;
+use solana_client::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -11,6 +12,7 @@ use crate::api::models::{
     ErrorResponse, JobResponse, JobStatus, JobVerificationResponse, RemoteStatusResponseWrapper,
     VerifyResponse,
 };
+use crate::solana_program::get_program_pda;
 
 // URL for the remote server
 pub const REMOTE_SERVER_URL: &str = "https://verify.osec.io";
@@ -109,10 +111,52 @@ pub async fn send_job_to_remote(
         .send()
         .await?;
 
+    handle_submission_response(&client, response, program_id).await
+}
+
+pub async fn send_job_with_uploader_to_remote(
+    connection: &RpcClient,
+    program_id: &Pubkey,
+    uploader: &Pubkey,
+) -> anyhow::Result<()> {
+    // Check that PDA exists before sending job
+    get_program_pda(connection, program_id, Some(uploader.to_string())).await?;
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(18000))
+        .build()?;
+
+    // Send the POST request
+    let response = client
+        .post(format!("{}/verify-with-signer", REMOTE_SERVER_URL))
+        .json(&json!({
+            "program_id": program_id.to_string(),
+            "signer": uploader.to_string(),
+            "repository": "",
+            "commit_hash": "",
+        }))
+        .send()
+        .await?;
+
+    handle_submission_response(&client, response, program_id).await
+}
+
+pub async fn handle_submission_response(
+    client: &Client,
+    response: Response,
+    program_id: &Pubkey,
+) -> anyhow::Result<()> {
     if response.status().is_success() {
-        let status_response: VerifyResponse = response.json().await?;
+        // First get the raw text to preserve it in case of parsing failure
+        let response_text = response.text().await?;
+        let status_response =
+            serde_json::from_str::<VerifyResponse>(&response_text).map_err(|e| {
+                eprintln!("Failed to parse response as VerifyResponse: {}", e);
+                eprintln!("Raw response: {}", response_text);
+                anyhow!("Failed to parse server response")
+            })?;
         let request_id = status_response.request_id;
-        println!("Verification request sent. ✅");
+        println!("Verification request sent with request id: {}", request_id);
         println!("Verification in progress... ⏳");
         // Span new thread for polling the server for status
         // Create a channel for communication between threads

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -248,3 +248,13 @@ pub async fn get_remote_status(program_id: Pubkey) -> anyhow::Result<()> {
     println!("{}", status);
     Ok(())
 }
+
+pub async fn get_remote_job(job_id: &str) -> anyhow::Result<()> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(18000))
+        .build()?;
+
+    let job = check_job_status(&client, job_id).await?;
+    println!("{}", job);
+    Ok(())
+}

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -8,7 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::api::models::{
-    ErrorResponse, JobResponse, JobStatus, JobVerificationResponse, VerifyResponse,
+    ErrorResponse, JobResponse, JobStatus, JobVerificationResponse, RemoteStatusResponseWrapper,
+    VerifyResponse,
 };
 
 // URL for the remote server
@@ -227,4 +228,23 @@ async fn check_job_status(client: &Client, request_id: &str) -> anyhow::Result<J
             response.text().await?
         ))?
     }
+}
+
+pub async fn get_remote_status(program_id: Pubkey) -> anyhow::Result<()> {
+    let client = Client::builder()
+        .timeout(Duration::from_secs(18000))
+        .build()?;
+
+    let response = client
+        .get(format!(
+            "{}/status-all/{}",
+            REMOTE_SERVER_URL,
+            program_id.to_string()
+        ))
+        .send()
+        .await?;
+
+    let status: RemoteStatusResponseWrapper = response.json().await?;
+    println!("{}", status);
+    Ok(())
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,4 +5,5 @@ mod solana;
 pub use client::get_remote_job;
 pub use client::get_remote_status;
 pub use client::send_job_to_remote;
+pub use client::send_job_with_uploader_to_remote;
 pub use solana::get_last_deployed_slot;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,7 @@ mod client;
 mod models;
 mod solana;
 
+pub use client::get_remote_job;
 pub use client::get_remote_status;
 pub use client::send_job_to_remote;
 pub use solana::get_last_deployed_slot;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,5 +2,6 @@ mod client;
 mod models;
 mod solana;
 
+pub use client::get_remote_status;
 pub use client::send_job_to_remote;
 pub use solana::get_last_deployed_slot;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -54,3 +54,49 @@ pub struct JobVerificationResponse {
     pub executable_hash: String,
     pub repo_url: String,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoteStatusResponse {
+    pub signer: String,
+    pub is_verified: bool,
+    pub on_chain_hash: String,
+    pub executable_hash: String,
+    pub repo_url: String,
+    pub commit: String,
+    pub last_verified_at: String,
+}
+
+impl std::fmt::Display for RemoteStatusResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Verification Status for Signer: {}", self.signer)?;
+        writeln!(
+            f,
+            "Verified: {}",
+            if self.is_verified { "✅" } else { "❌" }
+        )?;
+        writeln!(f, "On-chain Hash: {}", self.on_chain_hash)?;
+        writeln!(f, "Executable Hash: {}", self.executable_hash)?;
+        writeln!(f, "Repository URL: {}", self.repo_url)?;
+        writeln!(f, "Commit: {}", self.commit)?;
+        write!(f, "Last Verified: {}", self.last_verified_at)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoteStatusResponseWrapper(Vec<RemoteStatusResponse>);
+
+impl std::fmt::Display for RemoteStatusResponseWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, response) in self.0.iter().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+                writeln!(
+                    f,
+                    "----------------------------------------------------------------"
+                )?;
+            }
+            write!(f, "{}", response)?;
+        }
+        Ok(())
+    }
+}

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -34,6 +34,17 @@ pub struct JobResponse {
     pub respose: Option<JobVerificationResponse>,
 }
 
+impl std::fmt::Display for JobResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(response) = &self.respose {
+            writeln!(f, "{}", response)?;
+        } else {
+            writeln!(f, "Status: {:?}", self.status)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum JobStatus {
     #[serde(rename = "in_progress")]
@@ -53,6 +64,16 @@ pub struct JobVerificationResponse {
     pub on_chain_hash: String,
     pub executable_hash: String,
     pub repo_url: String,
+}
+
+impl std::fmt::Display for JobVerificationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Status: {:?}", self.status)?;
+        writeln!(f, "Message: {}", self.message)?;
+        writeln!(f, "On-chain Hash: {}", self.on_chain_hash)?;
+        writeln!(f, "Executable Hash: {}", self.executable_hash)?;
+        write!(f, "Repository URL: {}", self.repo_url)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,6 +219,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .subcommand(SubCommand::with_name("remote")
             .about("Send a command to a remote machine")
+        .setting(AppSettings::SubcommandRequiredElseHelp)
             .subcommand(SubCommand::with_name("get-status")
                 .about("Get the verification status of a program")
                 .arg(Arg::with_name("program-id")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use api::get_remote_status;
+use api::{get_remote_job, get_remote_status};
 use cargo_lock::Lockfile;
 use cargo_toml::Manifest;
 use clap::{App, AppSettings, Arg, SubCommand};
@@ -219,13 +219,21 @@ async fn main() -> anyhow::Result<()> {
         )
         .subcommand(SubCommand::with_name("remote")
             .about("Send a command to a remote machine")
-            .subcommand(SubCommand::with_name("status")
+            .subcommand(SubCommand::with_name("get-status")
                 .about("Get the verification status of a program")
                 .arg(Arg::with_name("program-id")
                     .long("program-id")
                     .required(true)
                     .takes_value(true)
-                    .help("The program address to fetch verification status for"))))
+                    .help("The program address to fetch verification status for")))
+
+            .subcommand(SubCommand::with_name("get-job")
+                .about("Get the status of a verification job")
+                .arg(Arg::with_name("job-id")
+                    .long("job-id")
+                    .required(true)
+                    .takes_value(true)))
+        )
         .get_matches();
 
     let connection = resolve_rpc_url(matches.value_of("url").map(|s| s.to_string()))?;
@@ -353,6 +361,10 @@ async fn main() -> anyhow::Result<()> {
             ("get-status", Some(sub_m)) => {
                 let program_id = sub_m.value_of("program-id").unwrap();
                 get_remote_status(Pubkey::try_from(program_id)?).await
+            }
+            ("get-job", Some(sub_m)) => {
+                let job_id = sub_m.value_of("job-id").unwrap();
+                get_remote_job(job_id).await
             }
             _ => unreachable!(),
         },

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -342,7 +342,7 @@ pub async fn get_program_pda(
         ))
     } else {
         Err(anyhow!(
-            "PDA not found for {:?} and uploader {:?}",
+            "PDA not found for {:?} and uploader {:?}. Make sure you've uploaded the PDA to mainnet.",
             program_id,
             signer_pubkey
         ))

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -341,7 +341,11 @@ pub async fn get_program_pda(
                 .map_err(|err| anyhow!("Unable to parse build params: {}", err))?,
         ))
     } else {
-        Err(anyhow!("PDA not found"))
+        Err(anyhow!(
+            "PDA not found for {:?} and uploader {:?}",
+            program_id,
+            signer_pubkey
+        ))
     }
 }
 


### PR DESCRIPTION
Adds subcommands under new group `remote`

```bash
$ solana-verify remote
solana-verify-remote 
Send a command to a remote machine

USAGE:
    solana-verify remote [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -u, --url <url>    Optionally include your RPC endpoint. Defaults to Solana CLI config file

SUBCOMMANDS:
    get-job       Get the status of a verification job
    get-status    Get the verification status of a program
    help          Prints this message or the help of the given subcommand(s)
    submit-job    Submit a verification job with with on-chain information
```

Primary change is that `solana-verify remote submit-job --program-id <program-id> --uploader <address>` now allows users to submit API verification requests by just submitting a request with a PDA (derived from the program id and whatever keypair wrote the build args to mainnet).