### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
This PR cuts a new release of solana-verify and bumps the version `0.4.0`.

Changes since 0.3.1:
- changed `solana-verify verify-from-repo --remote` to skip local build first, and go straight to writing the verification data unchain, then submitting a job to the OSec API
- added compute unit fees globally, used to achieve better landing rates for `solana-verify verify-from-repo --compute-unit-price`
- added `solana-verify remote submit-job <program id> --uploader <uploader>` now submits a remote job for <program ID> using only the PDA written by <uploader>
- added `solana-verify remote get-job --job-id <job-id>` gets the job status of a given job id
- added `solana-verify remote get-status  --program-id <program id>` gets the verification statuses by signer for a program ID
- added `solana-verify export-pda-tx --encoding base58/base64 --compute-unit-price 0` will now give you a base58/base64 transaction that you can use to write verification PDA from squads multisig
- improved error messages for `solana-verify verify-from-repo --remote` to encourage mutlisig users to use `solana-verify submit-job` when they need to verify a specific uploader's verification arguments. 
