### PR TITLE
Use verify-with-signer on --remote

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -89,45 +89,6 @@ fn print_verification_status(
     println!("Repo URL: {}", status_response.repo_url.as_str());
 }
 
-// Send a job to the remote server
-#[allow(clippy::too_many_arguments)]
-pub async fn send_job_to_remote(
-    repo_url: &str,
-    commit_hash: &Option<String>,
-    program_id: &Pubkey,
-    library_name: &Option<String>,
-    bpf_flag: bool,
-    relative_mount_path: String,
-    base_image: Option<String>,
-    cargo_args: Vec<String>,
-) -> anyhow::Result<()> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(18000))
-        .build()?;
-
-    // Send the POST request
-    let response = client
-        .post(format!("{}/verify", REMOTE_SERVER_URL))
-        .json(&json!({
-            "repository": repo_url,
-            "commit_hash": commit_hash,
-            "program_id": program_id.to_string(),
-            "lib_name": library_name,
-            "bpf_flag": bpf_flag,
-            "mount_path":  if relative_mount_path.is_empty() {
-                None
-            } else {
-                Some(relative_mount_path)
-            },
-            "base_image": base_image,
-            "cargo_args": cargo_args,
-        }))
-        .send()
-        .await?;
-
-    handle_submission_response(&client, response, program_id).await
-}
-
 pub async fn send_job_with_uploader_to_remote(
     connection: &RpcClient,
     program_id: &Pubkey,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,5 @@ mod solana;
 
 pub use client::get_remote_job;
 pub use client::get_remote_status;
-pub use client::send_job_to_remote;
 pub use client::send_job_with_uploader_to_remote;
 pub use solana::get_last_deployed_slot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use signal_hook::{
 };
 use solana_cli_config::{Config, CONFIG_FILE};
 use solana_client::rpc_client::RpcClient;
+use solana_program::get_address_from_keypair_or_config;
 use solana_sdk::{
     bpf_loader_upgradeable::{self, UpgradeableLoaderState},
     pubkey::Pubkey,
@@ -1265,7 +1266,7 @@ pub async fn verify_from_repo(
                     program_id,
                     connection,
                     skip_prompt,
-                    path_to_keypair,
+                    path_to_keypair.clone(),
                     compute_unit_price,
                 )
                 .await?;
@@ -1277,18 +1278,23 @@ pub async fn verify_from_repo(
                         return Err(anyhow!("Remote verification only works with mainnet. Please omit the --remote flag to verify locally."));
                     }
 
-                    println!("Sending verify command to remote machine...");
-                    send_job_to_remote(
-                        &repo_url,
-                        &commit_hash,
-                        &program_id,
-                        &library_name_opt.clone(),
-                        bpf_flag,
-                        relative_mount_path.clone(),
-                        base_image.clone(),
-                        cargo_args.clone(),
-                    )
-                    .await?;
+                    let uploader = get_address_from_keypair_or_config(path_to_keypair.as_ref())?;
+                    println!(
+                        "Sending verify command to remote machine with uploader: {}",
+                        &uploader
+                    );
+                    send_job_with_uploader_to_remote(&connection, &program_id, &uploader).await?;
+                    // send_job_to_remote(
+                    //     &repo_url,
+                    //     &commit_hash,
+                    //     &program_id,
+                    //     &library_name_opt.clone(),
+                    //     bpf_flag,
+                    //     relative_mount_path.clone(),
+                    //     base_image.clone(),
+                    //     cargo_args.clone(),
+                    // )
+                    // .await?;
                 }
 
                 Ok(())
@@ -1299,7 +1305,13 @@ pub async fn verify_from_repo(
                 Ok(())
             }
         }
-        Err(e) => Err(anyhow!("Error verifying program: {:?}", e)),
+        Err(e) => {
+            eprintln!(
+                "\nPlease note that if the desired uploader is not the provided keypair, you will need to run `solana-verify remote submit-job --program-id {} --uploader <uploader-address>.\n",
+                &program_id,
+            );
+            Err(anyhow!("Error verifying program: {:?}", e))
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,13 +38,10 @@ use image_config::IMAGE_MAP;
 #[cfg(test)]
 mod test;
 
-use crate::{
-    api::send_job_to_remote,
-    solana_program::{
-        compose_transaction, find_build_params_pda, get_all_pdas_available, get_program_pda,
-        process_close, resolve_rpc_url, upload_program_verification_data, InputParams,
-        OtterBuildParams, OtterVerifyInstructions,
-    },
+use crate::solana_program::{
+    compose_transaction, find_build_params_pda, get_all_pdas_available, get_program_pda,
+    process_close, resolve_rpc_url, upload_program_verification_data, InputParams,
+    OtterBuildParams, OtterVerifyInstructions,
 };
 
 const MAINNET_GENESIS_HASH: &str = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
@@ -1283,18 +1280,11 @@ pub async fn verify_from_repo(
                         "Sending verify command to remote machine with uploader: {}",
                         &uploader
                     );
-                    send_job_with_uploader_to_remote(&connection, &program_id, &uploader).await?;
-                    // send_job_to_remote(
-                    //     &repo_url,
-                    //     &commit_hash,
-                    //     &program_id,
-                    //     &library_name_opt.clone(),
-                    //     bpf_flag,
-                    //     relative_mount_path.clone(),
-                    //     base_image.clone(),
-                    //     cargo_args.clone(),
-                    // )
-                    // .await?;
+                    println!(
+                        "\nPlease note that if the desired uploader is not the provided keypair, you will need to run `solana-verify remote submit-job --program-id {} --uploader <uploader-address>.\n",
+                        &program_id,
+                    );
+                    send_job_with_uploader_to_remote(connection, &program_id, &uploader).await?;
                 }
 
                 Ok(())
@@ -1305,13 +1295,7 @@ pub async fn verify_from_repo(
                 Ok(())
             }
         }
-        Err(e) => {
-            eprintln!(
-                "\nPlease note that if the desired uploader is not the provided keypair, you will need to run `solana-verify remote submit-job --program-id {} --uploader <uploader-address>.\n",
-                &program_id,
-            );
-            Err(anyhow!("Error verifying program: {:?}", e))
-        }
+        Err(e) => Err(anyhow!("Error verifying program: {:?}", e)),
     }
 }
 

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -212,7 +212,7 @@ pub fn get_address_from_keypair_or_config(
     path_to_keypair: Option<&String>,
 ) -> anyhow::Result<Pubkey> {
     if let Some(path_to_keypair) = path_to_keypair {
-        Ok(get_keypair_from_path(&path_to_keypair)?.pubkey())
+        Ok(get_keypair_from_path(path_to_keypair)?.pubkey())
     } else {
         Ok(get_user_config()?.0.pubkey())
     }

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -208,6 +208,16 @@ pub fn resolve_rpc_url(url: Option<String>) -> anyhow::Result<RpcClient> {
     Ok(connection)
 }
 
+pub fn get_address_from_keypair_or_config(
+    path_to_keypair: Option<&String>,
+) -> anyhow::Result<Pubkey> {
+    if let Some(path_to_keypair) = path_to_keypair {
+        Ok(get_keypair_from_path(&path_to_keypair)?.pubkey())
+    } else {
+        Ok(get_user_config()?.0.pubkey())
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn upload_program_verification_data(
     git_url: String,
@@ -226,13 +236,7 @@ pub async fn upload_program_verification_data(
     {
         println!("Uploading the program verification params to the Solana blockchain...");
 
-        let cli_config = get_user_config()?;
-
-        let signer_pubkey: Pubkey = if let Some(ref path_to_keypair) = path_to_keypair {
-            get_keypair_from_path(path_to_keypair)?.pubkey()
-        } else {
-            cli_config.0.pubkey()
-        };
+        let signer_pubkey: Pubkey = get_address_from_keypair_or_config(path_to_keypair.as_ref())?;
 
         // let rpc_url = connection.url();
         println!("Using connection url: {}", connection.url());


### PR DESCRIPTION
Make API behavior consistent between `verify-from-repo --remote` and `remote submit-job`, and improve error messages.

Fixes #108 