### PR TITLE
Release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
This PR cuts a new release of solana-verify and bumps the version `0.4.1`.

Changes since `0.4.0`:
* fixed support for writing cargo args on-chain via `solana-verify export-pda-tx`
* Added support for programs built solana toolkit versions: 
  * v2.0.16
  * v2.0.17
  * v2.0.18
  * v2.0.19
  * v2.0.20
  * v2.0.21
  * v2.0.22
  * v2.1.1
  * v2.1.2
  * v2.1.3
  * v2.1.4
  * v2.1.5
  * v2.1.6
  * v2.1.7
  * v2.1.8
  * v2.1.9
