### PR TITLE
Release v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
This PR cuts a new release of solana-verify and bumps the version `0.4.2`.

Changes since `0.4.1`:
* added support for Cargo.lock format version `4` (fixed #135)
* Added support for programs built solana toolkit versions: 
  * v2.0.23
  * v2.0.24
  * v2.0.25
  * v2.1.10
  * v2.1.11
  * v2.1.13