### PR TITLE
fix: Handle exit code success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solana-verify"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"


### PR DESCRIPTION
### Problem
The API of Command looks misunderstood, it does not err on exit code not being a success but only if invocation of the command itself fails (command not found...). 

This leads to messed up CLI output, one has to read what happened above to deduce the actual real outcome of the command since it continues on failure silently.

A typical case is compilation failure then a program hash gets printed.

I think this can be more serious in some cases where a sequence of actions can lead to garbage unrelated hash in silence.

### Solution
Unfortunately there is no direct api it seems to err on status code. Use ensure! macro to validate the success

I didn't use the status code on anything that looks like a cleanup to avoid a failure and further cleanup