### PR TITLE
Add --config flag to specify custom configuration file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,7 +4425,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-verify"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-verify"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -97,7 +97,7 @@ pub async fn send_job_with_uploader_to_remote(
     // Check that PDA exists before sending job
     let genesis_hash = get_genesis_hash(connection)?;
     if genesis_hash != MAINNET_GENESIS_HASH {
-        return Err(anyhow!("Remote verification only works with mainnet. Please omit the --remote flag to verify locally."));
+        return Err(anyhow!("Remote verification service only supports mainnet. You're currently connected to a different network.\n\nTo use remote verification:\n• Connect to mainnet with: --url mainnet\n• Or remove the --remote flag to verify locally"));
     }
     get_program_pda(connection, program_id, Some(uploader.to_string()), None).await?;
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -99,7 +99,7 @@ pub async fn send_job_with_uploader_to_remote(
     if genesis_hash != MAINNET_GENESIS_HASH {
         return Err(anyhow!("Remote verification only works with mainnet. Please omit the --remote flag to verify locally."));
     }
-    get_program_pda(connection, program_id, Some(uploader.to_string())).await?;
+    get_program_pda(connection, program_id, Some(uploader.to_string()), None).await?;
 
     let client = Client::builder()
         .timeout(Duration::from_secs(18000))


### PR DESCRIPTION
- Adds a new `--config` flag that allows users to specify a custom Solana CLI configuration file path
- Enhance error handling by improving error messages.
