### PR TITLE
Release v0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,7 +4425,7 @@ checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-verify"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "base64 0.22.1",


### PR DESCRIPTION
Add `--arch` flag to match parity with latest `cargo build-sbf` tooling.

See #196 