### PR TITLE
feat: Download platform tools in image

### DIFF
--- a/generate_dockerfiles.py
+++ b/generate_dockerfiles.py
@@ -57,6 +57,11 @@ FROM --platform=linux/amd64 rust@{RUST_VERSION_PLACEHOLDER}
 RUN apt-get update && apt-get install -qy git gnutls-bin
 RUN sh -c "$(curl -sSfL https://release.anza.xyz/{AGAVE_VERSION_PLACEHOLDER}/install)"
 ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
+# Call cargo build-sbf to trigger installation of associated platform tools
+RUN cargo init temp && \\
+    cd temp && \\
+    cargo build-sbf && \\
+    rm -rf temp
 WORKDIR /build
 
 CMD /bin/bash


### PR DESCRIPTION
every single verifiable build the process has to download platform tools.
this also introduces another pointless critical download opening to supply chain attack.

Should this be backported to make new images since this does not change the output?