### PR TITLE
Support legacy BPF loaders (v1/v2) in get-program-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4462,6 +4462,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-sdk",
+ "solana-sdk-ids",
  "solana-system-interface",
  "solana-transaction-status-client-types",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ solana-rpc-client = "=2.3.1"
 solana-rpc-client-api = "=2.3.1"
 solana-transaction-status-client-types = "=2.3.1"
 solana-loader-v3-interface = "5.0.0"
+solana-sdk-ids = "2.2.1"
 solana-system-interface = "1.0.0"
 tokio = { version = "1.29.1", features = ["full"] }
 bincode = "1.3.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use solana_loader_v3_interface::{get_program_data_address, state::UpgradeableLoa
 use solana_program::get_address_from_keypair_or_config;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable};
 use solana_transaction_status_client_types::UiTransactionEncoding;
 use std::{
     io::Read,
@@ -735,31 +736,71 @@ pub fn get_buffer_hash(url: Option<String>, buffer_address: Pubkey) -> anyhow::R
 }
 
 pub fn get_program_hash(client: &RpcClient, program_id: Pubkey) -> anyhow::Result<String> {
-    // First check if the program account exists
-    retry_rpc_call(|| {
-        if client.get_account(&program_id).is_err() {
-            return Err(anyhow!("Program {} is not deployed", program_id));
-        }
-        Ok(())
+    let account = retry_rpc_call(|| {
+        client
+            .get_account(&program_id)
+            .map_err(|e| anyhow!("Program {} is not deployed: {}", program_id, e))
     })?;
 
-    let program_buffer = get_program_data_address(&program_id);
+    let owner = account.owner;
 
-    // Then check if the program data account exists
-    let offset = UpgradeableLoaderState::size_of_programdata_metadata();
-    retry_rpc_call(|| match client.get_account_data(&program_buffer) {
-        Ok(data) => {
-            let account_data = data[offset..].to_vec();
-            Ok(get_binary_hash(account_data))
-        }
-        Err(_) => Err(anyhow!(
-            "Could not find program data for {}. This could mean:\n\
+    match owner {
+        // Check if the program is owned by the upgradeable loader (Loader-v3)
+        // If so, the program data is in a separate program data account
+        owner_id if owner_id == bpf_loader_upgradeable::id() => {
+            let program_buffer = get_program_data_address(&program_id);
+
+            let data = retry_rpc_call(|| {
+                client.get_account_data(&program_buffer).map_err(|e| {
+                    anyhow!(
+                        "Could not find program data for {}: {}. This could mean:\n\
                      1. The program is not deployed\n\
                      2. The program is not upgradeable\n\
                      3. The program was deployed with a different loader",
-            program_id
+                        program_id,
+                        e
+                    )
+                })
+            })?;
+
+            let offset = UpgradeableLoaderState::size_of_programdata_metadata();
+
+            let account_data = data
+                .get(offset..)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Program data account appears corrupted or incomplete. Expected at least {} bytes for metadata.",
+                        offset
+                    )
+                })?
+                .to_vec();
+
+            Ok(get_binary_hash(account_data))
+        }
+
+        // Check if the program is owned by the legacy BPF loaders (v1/v2)
+        // If so, the program data is stored in the program account's data
+        owner_id if owner_id == bpf_loader_deprecated::id() || owner_id == bpf_loader::id() => {
+            let program_data = account.data;
+
+            if program_data.is_empty() {
+                return Err(anyhow!(
+                    "Program {} has no data (legacy loader account empty)",
+                    program_id
+                ));
+            }
+
+            Ok(get_binary_hash(program_data))
+        }
+
+        // Unsupported loader
+        _ => Err(anyhow!(
+            "Unknown or unsupported program loader. \
+             Program {} is owned by {}. Supported loaders: BPF Loader v1, v2, or Upgradeable (loader-v3).",
+            program_id,
+            owner
         )),
-    })
+    }
 }
 
 pub fn get_genesis_hash(client: &RpcClient) -> anyhow::Result<String> {
@@ -1096,10 +1137,7 @@ pub fn verify_from_image(
 
     let executable_hash: String = get_file_hash(program_filepath.as_str())?;
     let client = get_client(network, config_path);
-    let program_buffer = get_program_data_address(&program_id);
-    let offset = UpgradeableLoaderState::size_of_programdata_metadata();
-    let account_data = &client.get_account_data(&program_buffer)?[offset..];
-    let program_hash = get_binary_hash(account_data.to_vec());
+    let program_hash = get_program_hash(&client, program_id)?;
     println!("Executable hash: {}", executable_hash);
     println!("Program hash: {}", program_hash);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -180,4 +180,40 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_get_program_hash_legacy_loader() -> anyhow::Result<()> {
+        const SPL_TOKEN_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+        const EXPECTED_HASH: &str =
+            "d5a1793250f0f22efc7174bd8399570636e667655179642b2e90b0fb80e09106";
+        let args = ["get-program-hash", SPL_TOKEN_PROGRAM_ID];
+        let child = std::process::Command::new("./target/debug/solana-verify")
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("Failed to execute solana-verify command")?;
+
+        let output = child
+            .wait_with_output()
+            .context("Failed to wait for solana-verify command")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!(
+                "get-program-hash for legacy loader program failed: {}",
+                stderr
+            );
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let hash = stdout.trim();
+        assert_eq!(
+            hash, EXPECTED_HASH,
+            "Program hash {} does not match expected value {}",
+            hash, EXPECTED_HASH
+        );
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #216 

Programs deployed with BPF loader v1/v2 (e.g, SPL Token `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`) store executable in the program account's data. Whereas an upgradeable loader (loader-v3) stores the executable in a separate program data account. 

Previously, `get-program-hash` only supported the upgradeable loader (loader-v3) and would fail when called on programs deployed with legacy loaders (v1/v2). Now handling both cases:

- Detects the program’s loader via the account owner
- Handling upgradeable (loader-v3) programs by reading the ProgramData account
- Handling legacy (v1/v2) programs by hashing the program account’s data directly