### PR TITLE
ci: load github actions secrets from doppler

### DIFF
--- a/.github/workflows/ci-doppler-smoke.yaml
+++ b/.github/workflows/ci-doppler-smoke.yaml
@@ -1,0 +1,41 @@
+name: CI Doppler smoke test
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'doppler.yaml'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    environment: release-automation
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: false
+
+      - uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: docker.io
+          username: ${{ steps.doppler.outputs.DOCKER_USERNAME }}
+          password: ${{ steps.doppler.outputs.DOCKER_PASSWORD }}
+
+      - name: Validate PAT (read-only)
+        env:
+          GH_TOKEN: ${{ steps.doppler.outputs.SOLANA_VERIFIED_PROGRAMS_API_PAT }}
+        run: |
+          gh api user -q .login
+          gh api repos/otter-sec/solana-verified-programs-api -q .full_name
+
+      - name: Docker logout
+        if: always()
+        run: docker logout docker.io || true

--- a/.github/workflows/ci-doppler-smoke.yaml
+++ b/.github/workflows/ci-doppler-smoke.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
-          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'verifiable-build' }}
           doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
           inject-env-vars: false
 

--- a/.github/workflows/ci-doppler-smoke.yaml
+++ b/.github/workflows/ci-doppler-smoke.yaml
@@ -1,10 +1,6 @@
 name: CI Doppler smoke test
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - '.github/workflows/**'
-      - 'doppler.yaml'
 
 jobs:
   smoke:

--- a/.github/workflows/open-verified-programs-api-pr.yml
+++ b/.github/workflows/open-verified-programs-api-pr.yml
@@ -14,6 +14,10 @@ jobs:
   bump-api-dockerfile:
     if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
+    environment: release-automation
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Get version tag
@@ -38,11 +42,20 @@ jobs:
 
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Checkout API repository
         uses: actions/checkout@v4
         with:
           repository: otter-sec/solana-verified-programs-api
-          token: ${{ secrets.SOLANA_VERIFIED_PROGRAMS_API_PAT }}
+          token: ${{ steps.doppler.outputs.SOLANA_VERIFIED_PROGRAMS_API_PAT }}
           ref: master
 
       - name: Update version in api/Dockerfile
@@ -64,7 +77,7 @@ jobs:
       - name: Create pull request in API repo
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.SOLANA_VERIFIED_PROGRAMS_API_PAT }}
+          token: ${{ steps.doppler.outputs.SOLANA_VERIFIED_PROGRAMS_API_PAT }}
           commit-message: 'Update solana-verify to ${{ steps.meta.outputs.tag }}'
           title: 'Update solana-verify to ${{ steps.meta.outputs.tag }}'
           body: |

--- a/.github/workflows/open-verified-programs-api-pr.yml
+++ b/.github/workflows/open-verified-programs-api-pr.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
-          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'verifiable-build' }}
           doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
           inject-env-vars: true
 

--- a/.github/workflows/publish_all_dockerfiles.yaml
+++ b/.github/workflows/publish_all_dockerfiles.yaml
@@ -41,6 +41,7 @@ jobs:
         version: ${{ fromJson(needs.detect_changes.outputs.versions )}}
     name: Push Docker images to docker.io
     runs-on: ubuntu-latest
+    environment: release-automation
     permissions:
       packages: write
       contents: read
@@ -53,12 +54,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: docker.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ steps.doppler.outputs.DOCKER_USERNAME }}
+          password: ${{ steps.doppler.outputs.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish_all_dockerfiles.yaml
+++ b/.github/workflows/publish_all_dockerfiles.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
-          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'verifiable-build' }}
           doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
           inject-env-vars: true
 

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
-          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'verifiable-build' }}
           doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
           inject-env-vars: true
 

--- a/.github/workflows/publish_dockerfile.yaml
+++ b/.github/workflows/publish_dockerfile.yaml
@@ -12,6 +12,7 @@ jobs:
   push_to_registries:
     name: Push Docker image to ghcr.io
     runs-on: ubuntu-latest
+    environment: release-automation
     permissions:
       packages: write
       contents: read
@@ -21,12 +22,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        id: doppler
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-verifiable-build' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: docker.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ steps.doppler.outputs.DOCKER_USERNAME }}
+          password: ${{ steps.doppler.outputs.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  - project: solana-verifiable-build
+    config: dev_personal

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,3 +1,3 @@
 setup:
-  - project: solana-verifiable-build
+  - project: verifiable-build
     config: dev_personal


### PR DESCRIPTION
## Summary
- load Docker Hub and cross-repo automation credentials from Doppler using OIDC
- remove direct GitHub secret reads from the publish and API bump workflows
- add doppler.yaml with dev_personal as the local default config

## Test Plan
- not run locally in this session
