### PR TITLE
ci: enable signed commits for bot-generated PRs

### DIFF
--- a/.github/workflows/generate_dockerfiles.yml
+++ b/.github/workflows/generate_dockerfiles.yml
@@ -36,6 +36,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          sign-commits: true
           commit-message: Update Dockerfiles
           title: 'Update Dockerfiles'
           body: |

--- a/.github/workflows/update_existing_dockerfile_checksums.yml
+++ b/.github/workflows/update_existing_dockerfile_checksums.yml
@@ -36,6 +36,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          sign-commits: true
           commit-message: Update existing installer checksum pins
           title: "Update Existing Installer Checksums"
           body: |

--- a/.github/workflows/update_whitelist.yaml
+++ b/.github/workflows/update_whitelist.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          sign-commits: true
           commit-message: Update image whitelist
           title: 'Update Image Whitelist'
           body: |


### PR DESCRIPTION
### Problem
Automated PRs created by workflow jobs were blocked by branch protection (commits must have verified signatures) because bot commits were not signed.