### PR TITLE
Feat: add cargo-binstall metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,17 @@ version = "0.4.15"
 edition = "2021"
 description = "A CLI tool for building verifiable Solana programs"
 license = "MIT"
+repository = "https://github.com/solana-foundation/solana-verifiable-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[package.metadata.binstall]
+pkg-fmt = "bin"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-linux"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-macos"
 
 [dependencies]
 anyhow = "1.0.79"


### PR DESCRIPTION
Wires `cargo binstall solana-verify` to the existing release assets (`solana-verify-{version}-{linux|macos}`) so users can install a prebuilt binary without compiling from source. Tested on our fork and it works properly

Cargo binstall docs: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md


Closes #294 
