### PR TITLE
handle RPC errors when checking verification PDA (#293)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use image_config::IMAGE_MAP;
 mod test;
 
 use crate::solana_program::{
-    account_exists_or_err, compose_transaction, find_build_params_pda, get_all_pdas_available,
+    account_initialized_or_err, compose_transaction, find_build_params_pda, get_all_pdas_available,
     get_program_pda, process_close, resolve_rpc_url, upload_program_verification_data,
     validate_config_and_keypair, InputParams, OtterBuildParams, OtterVerifyInstructions,
 };
@@ -1831,9 +1831,8 @@ async fn export_pda_tx(
 
     let (pda, _) = find_build_params_pda(&program_id, &uploader);
 
-    // check if account already exists
-    // initialize only when account is missing
-    let instruction = match account_exists_or_err(connection, &pda)? {
+    // initialize only when account is missing or exists with empty data
+    let instruction = match account_initialized_or_err(connection, &pda)? {
         true => {
             println!("PDA already exists, creating update transaction");
             OtterVerifyInstructions::Update

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,9 @@ use image_config::IMAGE_MAP;
 mod test;
 
 use crate::solana_program::{
-    compose_transaction, find_build_params_pda, get_all_pdas_available, get_program_pda,
-    process_close, resolve_rpc_url, upload_program_verification_data, validate_config_and_keypair,
-    InputParams, OtterBuildParams, OtterVerifyInstructions,
+    account_exists_or_err, compose_transaction, find_build_params_pda, get_all_pdas_available,
+    get_program_pda, process_close, resolve_rpc_url, upload_program_verification_data,
+    validate_config_and_keypair, InputParams, OtterBuildParams, OtterVerifyInstructions,
 };
 
 const MAINNET_GENESIS_HASH: &str = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d";
@@ -1832,17 +1832,16 @@ async fn export_pda_tx(
     let (pda, _) = find_build_params_pda(&program_id, &uploader);
 
     // check if account already exists
-    let instruction = match connection.get_account(&pda) {
-        Ok(account_info) => {
-            if !account_info.data.is_empty() {
-                println!("PDA already exists, creating update transaction");
-                OtterVerifyInstructions::Update
-            } else {
-                println!("PDA does not exist, creating initialize transaction");
-                OtterVerifyInstructions::Initialize
-            }
+    // initialize only when account is missing
+    let instruction = match account_exists_or_err(connection, &pda)? {
+        true => {
+            println!("PDA already exists, creating update transaction");
+            OtterVerifyInstructions::Update
         }
-        Err(_) => OtterVerifyInstructions::Initialize,
+        false => {
+            println!("PDA does not exist, creating initialize transaction");
+            OtterVerifyInstructions::Initialize
+        }
     };
 
     let tx = compose_transaction(

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -35,18 +35,33 @@ fn is_account_not_found_error(err: &anyhow::Error) -> bool {
 pub fn account_exists_or_err(connection: &RpcClient, address: &Address) -> anyhow::Result<bool> {
     match connection.get_account(address) {
         Ok(_) => Ok(true),
-        Err(err) => {
-            let err_anyhow = anyhow!(err);
-            if is_account_not_found_error(&err_anyhow) {
-                Ok(false)
-            } else {
-                Err(anyhow!(
-                    "RPC error while checking account {} existence: {}",
-                    address,
-                    err_anyhow
-                ))
-            }
-        }
+        Err(err) => account_missing_from_get_account_error(address, err),
+    }
+}
+
+pub fn account_initialized_or_err(
+    connection: &RpcClient,
+    address: &Address,
+) -> anyhow::Result<bool> {
+    match connection.get_account(address) {
+        Ok(account) => Ok(!account.data.is_empty()),
+        Err(err) => account_missing_from_get_account_error(address, err),
+    }
+}
+
+fn account_missing_from_get_account_error(
+    address: &Address,
+    err: impl std::error::Error + Send + Sync + 'static,
+) -> anyhow::Result<bool> {
+    let err_anyhow = anyhow!(err);
+    if is_account_not_found_error(&err_anyhow) {
+        Ok(false)
+    } else {
+        Err(anyhow!(
+            "RPC error while checking account {} existence: {}",
+            address,
+            err_anyhow
+        ))
     }
 }
 
@@ -539,12 +554,12 @@ mod account_exists_tests {
     const TEST_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 
     #[test]
+    #[ignore = "requires network; run: cargo test account_exists_or_err_test -- --ignored"]
     fn account_exists_or_err_test() {
         let client = RpcClient::new("https://api.mainnet-beta.solana.com");
         let program_id = Address::from_str(TEST_PROGRAM_ID).unwrap();
 
         let exists = account_exists_or_err(&client, &program_id).unwrap();
-        println!("exists: {exists}");
-        assert!(exists, "SPL Token program account should exist on mainnet");
+        assert!(exists, "Test program account should exist on mainnet");
     }
 }

--- a/src/solana_program.rs
+++ b/src/solana_program.rs
@@ -27,6 +27,29 @@ const OTTER_VERIFY_PROGRAM_ID: Address =
 const OTTER_SIGNER: Address =
     Address::from_str_const("9VWiUUhgNoRwTH5NVehYJEDwcotwYX3VgW4MChiHPAqU");
 
+fn is_account_not_found_error(err: &anyhow::Error) -> bool {
+    let err_text = err.to_string();
+    err_text.contains("AccountNotFound") || err_text.contains("Account does not exist")
+}
+
+pub fn account_exists_or_err(connection: &RpcClient, address: &Address) -> anyhow::Result<bool> {
+    match connection.get_account(address) {
+        Ok(_) => Ok(true),
+        Err(err) => {
+            let err_anyhow = anyhow!(err);
+            if is_account_not_found_error(&err_anyhow) {
+                Ok(false)
+            } else {
+                Err(anyhow!(
+                    "RPC error while checking account {} existence: {}",
+                    address,
+                    err_anyhow
+                ))
+            }
+        }
+    }
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub struct OtterBuildParams {
     pub address: Address,
@@ -322,7 +345,7 @@ pub async fn upload_program_verification_data(
         // Possible PDA-2: signer is otter signer
         let pda_account_2 = find_build_params_pda(&program_address, &OTTER_SIGNER).0;
 
-        if connection.get_account(&pda_account_1).is_ok() {
+        if account_exists_or_err(connection, &pda_account_1)? {
             println!("Program already uploaded by the current signer. Updating the program.");
             process_otter_verify_ixs(
                 &input_params,
@@ -334,7 +357,7 @@ pub async fn upload_program_verification_data(
                 compute_unit_price,
                 config_path.clone(),
             )?;
-        } else if connection.get_account(&pda_account_2).is_ok() {
+        } else if account_exists_or_err(connection, &pda_account_2)? {
             let wanna_create_new_pda = skip_prompt || prompt_user_input(
                 "Program already uploaded by another signer. Do you want to upload a new program? (Y/n)"
             );
@@ -398,7 +421,7 @@ pub async fn process_close(
 
     let pda_account = find_build_params_pda(&program_address, &signer_address).0;
 
-    if connection.get_account(&pda_account).is_ok() {
+    if account_exists_or_err(connection, &pda_account)? {
         process_otter_verify_ixs(
             &InputParams {
                 version: "".to_string(),
@@ -506,4 +529,22 @@ pub async fn get_all_pdas_available(
     }
 
     Ok(pdas)
+}
+
+#[cfg(test)]
+mod account_exists_tests {
+    use super::*;
+    use std::str::FromStr;
+
+    const TEST_PROGRAM_ID: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+
+    #[test]
+    fn account_exists_or_err_test() {
+        let client = RpcClient::new("https://api.mainnet-beta.solana.com");
+        let program_id = Address::from_str(TEST_PROGRAM_ID).unwrap();
+
+        let exists = account_exists_or_err(&client, &program_id).unwrap();
+        println!("exists: {exists}");
+        assert!(exists, "SPL Token program account should exist on mainnet");
+    }
 }


### PR DESCRIPTION
Fixes #293.

When `get_account` failed (e.g. temporary RPC issues), the CLI treated it as “PDA missing” and tried `Initialize`, which could fail with `account already in use` even when the PDA existed.

Now we only use `Initialize` when the account is really missing. Other RPC errors return a clear error instead.